### PR TITLE
XmlPayload added

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Parses the body of the request if it's not parsed and the method is POST, PUT or
 * [JsonPayload](#jsonpayload)
 * [UrlEncodePayload](#urlencodepayload)
 * [CsvPayload](#csvpayload)
+* [XmlPayload](#xmlpayload)
 
 Failure to parse the body will result in a `Middlewares\Utils\HttpErrorException` being thrown. See [middlewares/utils](https://github.com/middlewares/utils#httperrorexception) for additional details.
 
@@ -31,7 +32,7 @@ composer require middlewares/payload
 
 ## JsonPayload
 
-Parses the json payload of the request.
+Parses the JSON payload of the request.
 
 ```php
 $dispatcher = new Dispatcher([
@@ -133,6 +134,11 @@ Type | Required | Description
 ## CsvPayload
 
 CSV payloads are supported by the [middlewares/csv-payload](https://packagist.org/packages/middlewares/csv-payload) package.
+
+
+## XmlPayload
+
+Parses the XML payload of the request. It returns an instance of [SimpleXMLElement](https://www.php.net/manual/en/class.simplexmlelement.php).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ CSV payloads are supported by the [middlewares/csv-payload](https://packagist.or
 
 ## XmlPayload
 
-Parses the XML payload of the request. It returns an instance of [SimpleXMLElement](https://www.php.net/manual/en/class.simplexmlelement.php).
+Parses the XML payload of the request. Parsed body will return an instance of [SimpleXMLElement](https://www.php.net/manual/en/class.simplexmlelement.php).
 
 ---
 

--- a/src/XmlPayload.php
+++ b/src/XmlPayload.php
@@ -5,6 +5,7 @@ namespace Middlewares;
 
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Server\MiddlewareInterface;
+use SimpleXMLElement;
 
 class XmlPayload extends Payload implements MiddlewareInterface
 {
@@ -13,33 +14,12 @@ class XmlPayload extends Payload implements MiddlewareInterface
      */
     protected $contentType = ['text/xml', 'application/xml', 'application/x-xml'];
 
-    private $associative = true;
-
-    /**
-     * Configure the returned object to be converted into an array instead of an object.
-     */
-    public function associative(bool $associative = true): self
-    {
-        $this->associative = $associative;
-
-        return $this;
-    }
-
     /**
      * {@inheritdoc}
      */
     protected function parse(StreamInterface $stream)
     {
-        $xml = trim((string)$stream);
-
-        if ($xml === '') {
-            return $this->associative ? [] : null;
-        }
-
-        $xml = simplexml_load_string($xml);
-        $json = json_encode($xml);
-        $array = json_decode($json, $this->associative);
-
-        return $array;
+        $string = trim((string)$stream);
+        return new SimpleXMLElement($string);
     }
 }

--- a/src/XmlPayload.php
+++ b/src/XmlPayload.php
@@ -20,6 +20,11 @@ class XmlPayload extends Payload implements MiddlewareInterface
     protected function parse(StreamInterface $stream)
     {
         $string = trim((string)$stream);
+
+        if (empty($string)) {
+            return null;
+        }
+
         return new SimpleXMLElement($string);
     }
 }

--- a/src/XmlPayload.php
+++ b/src/XmlPayload.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types = 1);
+
+namespace Middlewares;
+
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Server\MiddlewareInterface;
+
+class XmlPayload extends Payload implements MiddlewareInterface
+{
+    /**
+     * @var array
+     */
+    protected $contentType = ['text/xml', 'application/xml', 'application/x-xml'];
+
+    private $associative = true;
+
+    /**
+     * Configure the returned object to be converted into an array instead of an object.
+     */
+    public function associative(bool $associative = true): self
+    {
+        $this->associative = $associative;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function parse(StreamInterface $stream)
+    {
+        $xml = trim((string)$stream);
+
+        if ($xml === '') {
+            return $this->associative ? [] : null;
+        }
+
+        $xml = simplexml_load_string($xml);
+        $json = json_encode($xml);
+        $array = json_decode($json, $this->associative);
+
+        return $array;
+    }
+}

--- a/src/XmlPayload.php
+++ b/src/XmlPayload.php
@@ -21,7 +21,7 @@ class XmlPayload extends Payload implements MiddlewareInterface
     {
         $string = trim((string)$stream);
 
-        if (empty($string)) {
+        if ($string === '') {
             return null;
         }
 

--- a/tests/PayloadTest.php
+++ b/tests/PayloadTest.php
@@ -21,7 +21,8 @@ class PayloadTest extends TestCase
             ['application/json', '', []],
             ['application/x-www-form-urlencoded', 'bar=foo', ['bar' => 'foo']],
             ['application/x-www-form-urlencoded', '', []],
-            ['application/xml', '<root><bar>foo</bar></root>', new SimpleXMLElement('<root><bar>foo</bar></root>')]
+            ['application/xml', '<root><bar>foo</bar></root>', new SimpleXMLElement('<root><bar>foo</bar></root>')],
+            ['application/xml', '', null],
         ];
     }
 


### PR DESCRIPTION
What do you think? :sweat_smile: 

This  following code is just to convert the SimpleXML object to an array or a simple object (stdClass), this way it's more consistent to JSON payload and also if at some point we want to change the XML parser, it won't have any effect because we will still return simple arrays and objects (stdClass).

```php
$json = json_encode($xml);
$array = json_decode($json, $this->associative);
```